### PR TITLE
Support for legacy device

### DIFF
--- a/bpf/headers/include/bpf/KernelUtils.h
+++ b/bpf/headers/include/bpf/KernelUtils.h
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/personality.h>
+#include <sys/system_properties.h>
 #include <sys/utsname.h>
 
 namespace android {
@@ -33,7 +34,13 @@ static inline unsigned uncachedKernelVersion() {
     unsigned kver_major = 0;
     unsigned kver_minor = 0;
     unsigned kver_sub = 0;
-    (void)sscanf(buf.release, "%u.%u.%u", &kver_major, &kver_minor, &kver_sub);
+    char kver_override[PROP_VALUE_MAX];
+    int kver_override_len = __system_property_get("ro.bpf.kver_override", kver_override);
+    if (kver_override_len > 0) {
+        (void)sscanf(kver_override, "%u.%u.%u", &kver_major, &kver_minor, &kver_sub);
+    } else {
+        (void)sscanf(buf.release, "%u.%u.%u", &kver_major, &kver_minor, &kver_sub);
+    }
     return KVER(kver_major, kver_minor, kver_sub);
 }
 

--- a/bpf/loader/NetBpfLoad.cpp
+++ b/bpf/loader/NetBpfLoad.cpp
@@ -1696,28 +1696,24 @@ static int doLoad(char** argv, char * const envp[]) {
 
     // both S and T require kernel 4.9 (and eBpf support)
     if (!isAtLeastKernelVersion(4, 9, 0)) {
-        ALOGE("Android S & T require kernel 4.9.");
-        return 1;
+        ALOGW("Android S & T require kernel 4.9.");
     }
 
     // U bumps the kernel requirement up to 4.14
     if (isAtLeastU && !isAtLeastKernelVersion(4, 14, 0)) {
-        ALOGE("Android U requires kernel 4.14.");
-        return 1;
+        ALOGW("Android U requires kernel 4.14.");
     }
 
     // V bumps the kernel requirement up to 4.19
     // see also: //system/netd/tests/kernel_test.cpp TestKernel419
     if (isAtLeastV && !isAtLeastKernelVersion(4, 19, 0)) {
-        ALOGE("Android V requires kernel 4.19.");
-        return 1;
+        ALOGW("Android V requires kernel 4.19.");
     }
 
     // 25Q2 bumps the kernel requirement up to 5.4
     // see also: //system/netd/tests/kernel_test.cpp TestKernel54
     if (isAtLeast25Q2 && !isAtLeastKernelVersion(5, 4, 0)) {
-        ALOGE("Android 25Q2 requires kernel 5.4.");
-        return 1;
+        ALOGW("Android 25Q2 requires kernel 5.4.");
     }
 
     // Technically already required by U, but only enforce on V+

--- a/bpf/loader/NetBpfLoad.cpp
+++ b/bpf/loader/NetBpfLoad.cpp
@@ -1861,12 +1861,14 @@ static int doLoad(char** argv, char * const envp[]) {
         //  kernel does not have CONFIG_BPF_JIT=y)
         // BPF_JIT is required by R VINTF (which means 4.14/4.19/5.4 kernels),
         // but 4.14/4.19 were released with P & Q, and only 5.4 is new in R+.
-        if (writeProcSysFile("/proc/sys/net/core/bpf_jit_enable", "1\n")) return 1;
+        if (writeProcSysFile("/proc/sys/net/core/bpf_jit_enable", "1\n") &&
+            android::bpf::isAtLeastKernelVersion(4, 14, 0)) return 1;
 
         // Enable JIT kallsyms export for privileged users only
         // (Note: this (open) will fail with ENOENT 'No such file or directory' if
         //  kernel does not have CONFIG_HAVE_EBPF_JIT=y)
-        if (writeProcSysFile("/proc/sys/net/core/bpf_jit_kallsyms", "1\n")) return 1;
+        if (writeProcSysFile("/proc/sys/net/core/bpf_jit_kallsyms", "1\n") &&
+            android::bpf::isAtLeastKernelVersion(4, 14, 0)) return 1;
     }
 
     // Create all the pin subdirectories

--- a/bpf/netd/BpfHandler.cpp
+++ b/bpf/netd/BpfHandler.cpp
@@ -81,29 +81,9 @@ static Status initPrograms(const char* cg2_path) {
     // This code was mainlined in T, so this should be trivially satisfied.
     if (!isAtLeastT) return Status("S- platform is unsupported");
 
-    // S requires eBPF support which was only added in 4.9, so this should be satisfied.
-    if (!isAtLeastKernelVersion(4, 9, 0)) {
-        return Status("kernel version < 4.9.0 is unsupported");
-    }
-
-    // U bumps the kernel requirement up to 4.14
-    if (isAtLeastU && !isAtLeastKernelVersion(4, 14, 0)) {
-        return Status("U+ platform with kernel version < 4.14.0 is unsupported");
-    }
-
     // U mandates this mount point (though it should also be the case on T)
     if (isAtLeastU && !!strcmp(cg2_path, "/sys/fs/cgroup")) {
         return Status("U+ platform with cg2_path != /sys/fs/cgroup is unsupported");
-    }
-
-    // V bumps the kernel requirement up to 4.19
-    if (isAtLeastV && !isAtLeastKernelVersion(4, 19, 0)) {
-        return Status("V+ platform with kernel version < 4.19.0 is unsupported");
-    }
-
-    // 25Q2 bumps the kernel requirement up to 5.4
-    if (isAtLeast25Q2 && !isAtLeastKernelVersion(5, 4, 0)) {
-        return Status("25Q2+ platform with kernel version < 5.4.0 is unsupported");
     }
 
     unique_fd cg_fd(open(cg2_path, O_DIRECTORY | O_RDONLY | O_CLOEXEC));


### PR DESCRIPTION
It's just a relaxation of the kernel version restriction, and actually requires more stuff to make the old kernel work.